### PR TITLE
Fixed references to train.nzoi.org.nz

### DIFF
--- a/nzic/faq.md
+++ b/nzic/faq.md
@@ -23,7 +23,7 @@ If you would like to sponsor a prize, please [contact us](mailto:nzic@nzoi.org.n
 
 ### How can I practice?
 
-Visit [train.nzoi.org.nz](train.nzoi.org.nz).
+Visit [train.nzoi.org.nz](https://train.nzoi.org.nz).
 
 ### What type of problems will be in the contest?
 

--- a/nzic/index.md
+++ b/nzic/index.md
@@ -24,7 +24,7 @@ Dates for NZIC 2021 have yet to be set.
 
 ### Overview
 
-Log in to our training site and start the competition at any point between the above dates. Once a student has begun the competition they typically have **3 hours** to view the problems and submit solutions. During their 3 hours, students are **not** permitted to access any websites (other than [train.nzoi.org.nz](train.nzoi.org.nz)) or collaborate with any others. This is an individual contest. You are, however, permitted to consult the documentation for your chosen programming language during the contest - remembering syntax can be hard. For details, please view the offical [rules](rules).
+Log in to our training site and start the competition at any point between the above dates. Once a student has begun the competition they typically have **3 hours** to view the problems and submit solutions. During their 3 hours, students are **not** permitted to access any websites (other than [train.nzoi.org.nz](https://train.nzoi.org.nz)) or collaborate with any others. This is an individual contest. You are, however, permitted to consult the documentation for your chosen programming language during the contest - remembering syntax can be hard. For details, please view the offical [rules](rules).
 
 If you're at a school with multiple students wanting to participate you might want to arrange to all sit it at the same time, either after school or during class time (with a teacher's support).
 

--- a/nzic/resources.md
+++ b/nzic/resources.md
@@ -8,7 +8,7 @@ nzic_weight: 45
 
 - [Installing and using C++](cpp-install-instructions.pdf)
 
-Using [train.nzoi.org.nz](train.nzoi.org.nz):
+Using [train.nzoi.org.nz](https://train.nzoi.org.nz):
 
 - [How our servers mark your code (Python 3 example)](how-judging-works-python3.pdf)
 - [Understanding judge feedback](understanding-judge-feedback.pdf)
@@ -18,7 +18,7 @@ Competitive programming books:
 - [Competitive Programming 1](https://www.comp.nus.edu.sg/~stevenha/myteaching/competitive_programming/cp1.pdf)
 - [Competitive Programming Handbook](https://cses.fi/book/book.pdf)
 
-Sources of problems (other than our own [train.nzoi.org.nz](train.nzoi.org.nz)):
+Sources of problems (other than our own [train.nzoi.org.nz](https://train.nzoi.org.nz)):
 
 - US: [http://train.usaco.org/usacogate](http://train.usaco.org/usacogate)
 - Australia: [http://orac.amt.edu.au/cgi-bin/train/hub.pl](http://orac.amt.edu.au/cgi-bin/train/hub.pl)


### PR DESCRIPTION
There are a couple of places where the train.nzoi.o.n doesn't actually redirect to the training site, but instead redirect to a relative url on the information site which doesn't exist. This PR fixes these issues.